### PR TITLE
Upgrade firebase/php-jwt to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "require": {
     "php": ">=8.3 <8.6",
-    "firebase/php-jwt": "^6",
+    "firebase/php-jwt": "^7",
     "ext-openssl": "*"
   },
   "require-dev": {

--- a/tests/JwtWrapperHashTest.php
+++ b/tests/JwtWrapperHashTest.php
@@ -34,7 +34,7 @@ class JwtWrapperHashTest extends TestCase
     #[Override]
     protected function setUp(): void
     {
-        $this->jwtKey = JwtHashHmacSecret::getInstance("secrect_key_for_test", false);
+        $this->jwtKey = JwtHashHmacSecret::getInstance("secrect_key_for_test_that_is_long_enough_for_hs512_algorithm_works", false);
 
         unset($_SERVER["HTTP_AUTHORIZATION"]);
         $this->object = new JwtWrapper($this->server, $this->jwtKey);
@@ -174,7 +174,7 @@ class JwtWrapperHashTest extends TestCase
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $jwtWrapper = new JwtWrapper($this->server, new JwtHashHmacSecret("some_creepy_secret", true));
+        $jwtWrapper = new JwtWrapper($this->server, new JwtHashHmacSecret("some_other_creepy_secret_that_is_long_enough_for_hs512_algorithm", false));
 
         $jwtWrapper->extractData($token);
     }


### PR DESCRIPTION
Upgraded the `firebase/php-jwt` library to version 7 to address vulnerabilities identified in version 6. This ensures enhanced security and compliance with the latest advisories.